### PR TITLE
FAT: Fix warning

### DIFF
--- a/fs/fat/dir.c
+++ b/fs/fat/dir.c
@@ -1240,7 +1240,7 @@ int fat_add_entries(struct inode *dir, void *slots, int nr_slots,
 	struct super_block *sb = dir->i_sb;
 	struct msdos_sb_info *sbi = MSDOS_SB(sb);
 	struct buffer_head *bh, *prev, *bhs[3]; /* 32*slots (672bytes) */
-	struct msdos_dir_entry *de;
+	struct msdos_dir_entry *de = NULL;
 	int err, free_slots, i, nr_bhs;
 	loff_t pos, i_pos;
 


### PR DESCRIPTION
fs/fat/dir.c:43: warning: 'de' may be used uninitialized in this function

The complexity of the code flow makes this seem possible.  Initialize
the value to NULL to eliminate the compiler warning.  This only masks
the warning, since if the value were unused, there would still be a
NULL pointer.

Change-Id: I9fc36abace09409853b63e0997328b75ce703769
Signed-off-by: David Brown davidb@codeaurora.org
